### PR TITLE
fix: SELinux context of vendor_file

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -38,3 +38,4 @@ for FILE in $(ls $MODPATH/system/product/etc/device_features/*); do
 done
 
 set_perm_recursive "$MODPATH" 0 0 0755 0644
+set_perm_recursive "$MODPATH/system/vendor" 0 0 0755 0644 "u:object_r:vendor_file:s0"

--- a/module.prop
+++ b/module.prop
@@ -1,7 +1,7 @@
 id=io.varieget.miuiforcedc
 name=MIUI 强制开启 DC 调光
-version=v2.0.0
-versionCode=200
+version=v2.1.0
+versionCode=210
 author=varieget
 description=使得 设置 > 显示 > 屏幕 出现 “防闪烁模式” 开关选项，GitHub: https://github.com/varieget/miui-force-DC
 updateJson=https://varieget.github.io/miui-force-DC/releases/update.json

--- a/service.sh
+++ b/service.sh
@@ -2,9 +2,9 @@
 MODDIR=${0%/*}
 
 set_dc_backlight() {
-  DC_BACK_LIGHT=$(settings list system | grep dc_back_light)
+  DC_BACK_LIGHT=$(cmd settings get system dc_back_light 2>/dev/null)
 
-  if [[ $DC_BACK_LIGHT == *"dc_back_light=1"* ]]; then
+  if [ $DC_BACK_LIGHT == "1" ]; then
     resetprop 'persist.vendor.dc_backlight.enable' 'true'
     input keyevent 26
   fi


### PR DESCRIPTION
将 `displayfeature.default.so` 的 SELinux 上下文由 Magisk 默认的 `u:object_r:system_file:s0` 修改为 `u:object_r:vendor_file:s0`